### PR TITLE
Change moves container to unordered_map

### DIFF
--- a/src/helper/Board.h
+++ b/src/helper/Board.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <vector>
+#include <unordered_map>
 #include <iostream>
 #include "Move.h"
 #include "Tile.h"
@@ -13,13 +14,16 @@ public:
     Board(std::vector<Tile*> copyPieces[2]);
     //void InitializeBoard(); // maybe not needed since constructor can initialize
     void PieceMoves(std::vector<Move>& moves, Tile* aTile, bool turn);
-    std::vector<Move> PossibleMoves(bool turn);
+    void PieceMoves(std::unordered_map<std::string, std::vector<Move>>& moves, Tile* aTile, bool turn);
+    //std::vector<Move> PossibleMoves(bool turn);
+    std::unordered_map<std::string, std::vector<Move>> PossibleMoves(bool turn);
     void PrintBoard(); // on terminal
     void MovePiece(std::string start, std::string end);
     void MovePiece(Move m, bool);
     //std::set<std::string> ThreatenedTiles(bool turn);
-    std::vector<Move> LegalMoves(bool turn);
-    
+    //std::vector<Move> LegalMoves(bool turn);
+    std::unordered_map<std::string, std::vector<Move>> LegalMoves(bool turn);
+
     // check game status functions
     bool Check(bool turn);
     bool Checkmate(bool turn);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,23 +17,40 @@ int main()
     bool end_game = false;
     while(board.LegalMoves(turn).size() > 0){
         std::cout << "Choose your move, player " << turn + 1 << ".\n";
-        std::vector<Move> moves = board.LegalMoves(turn);
-        // std::vector<Move> possibles = board.PossibleMoves(turn);
-        for(int i = 0; i < moves.size(); i++)
-            std::cout << i << ". " << moves.at(i).notation << std::endl;
-        int input;
+        std::unordered_map<std::string, std::vector<Move>> moves = board.LegalMoves(turn);
+        
+        std::string input = "";
         std::cin >> input;
-        if(input >= moves.size() || input < 0){
-            std::cout << "Please choose one of the following moves.\n";
+        if(moves[input].size() == 0){
+            std::cout << "Please choose a legal move.\n";
             continue;
         }
-        board.MovePiece(moves.at(input), turn);
+        int i = 0;
+        if(moves[input].size() > 1){
+            std::cout << "Please choose which piece moves to " << input << std::endl;
+            for(i = 0; i < moves[input].size(); i++){
+                int row = moves[input].at(i).fromTile->GetRow();
+                int col = moves[input].at(i).fromTile->GetCol();
+                std::string piece = moves[input].at(i).fromTile->GetPiece() + CtoP(row, col);
+                
+                std::cout << i + 1 << ". " << piece << std::endl;
+            }
+            int input2;
+            std::cin >> input2;
+            if(input2 < 0 || input2 >= moves[input].size()){
+                "Please choose a legal move.\n";
+                continue;
+            }
+            else    
+                i = input2 - 1;
+        }
+        board.MovePiece(moves[input].at(i), turn);
         std::string suffix = "";
         if(board.Checkmate(turn))
             break;
         else if(board.Check(turn))
             suffix = "+";
-        std::cout << "Player " << turn + 1 << " moves " << moves.at(input).notation + suffix << std::endl;
+        std::cout << "Player " << turn + 1 << " moves " << input + suffix << std::endl;
         count++;
         turn = !turn;
         board.PrintBoard();


### PR DESCRIPTION
- Change all Board functions and main.cpp game logic to handle unordered_map<string, vector<Move>> instead of vector<Move>, where the key is the notation and the vector contains all moves with that notation. 
- Modify input of game logic to handle algebraic notation instead of an integer from the list, as well as outputting a list when a destination tile has two similar move notations (e.g. two rooks moving to the exact same tile)